### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/wdeve/44680bd8-e24d-4f58-a7c1-88dfb50e5d00/105dfc51-0073-4f75-a891-200335232e34/_apis/work/boardbadge/bd4eb437-7816-49c7-95f8-8e466de2a07b)](https://dev.azure.com/wdeve/44680bd8-e24d-4f58-a7c1-88dfb50e5d00/_boards/board/t/105dfc51-0073-4f75-a891-200335232e34/Microsoft.RequirementCategory)
 Calculator.js: a node.js Demonstration Project
 ==============================================
 An example node.js project, including tests with mocha, that behaves like


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1048](https://dev.azure.com/wdeve/44680bd8-e24d-4f58-a7c1-88dfb50e5d00/_workitems/edit/1048). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.